### PR TITLE
Fix/req_token_key_error

### DIFF
--- a/json_formatter.py
+++ b/json_formatter.py
@@ -4,8 +4,6 @@
 
 class JsonFormatter(object):
 
-
-
     def init_tweet_list_json(self, search_word_dict, search_result):
 
         tweet_list_json = {}

--- a/model.py
+++ b/model.py
@@ -2,8 +2,12 @@
 
 import json
 
+
+
 class Model(object):
-    print("have I ever used?")
+
+
+
     def load_search_result(self, path = 'json_data/search_1135_ja.json'):
         f = open(path, 'r')
         search_result_read = json.load(f)

--- a/model.py
+++ b/model.py
@@ -6,8 +6,6 @@ import json
 
 class Model(object):
 
-
-
     def load_search_result(self, path = 'json_data/search_1135_ja.json'):
         f = open(path, 'r')
         search_result_read = json.load(f)

--- a/router.py
+++ b/router.py
@@ -11,7 +11,7 @@ CONSUMER_KEY    = SETTING['twitter']['CONSUMER_KEY']
 CONSUMER_SECRET = SETTING['twitter']['CONSUMER_SECRET']
 CALLBACK_URL    = SETTING['twitter']['CALLBACK_URL']
 
-# sess = {}
+sess = {}
 
 app = Flask(__name__)
 app.secret_key = SETTING['flask']['SECRET_KEY']
@@ -55,11 +55,11 @@ def oauth():
 
     try:
         redirect_url = auth.get_authorization_url()
-        # sess['request_token'] = (auth.request_token)
-        session['request_token'].append(auth.request_token)
-        session.modified = True
+        sess['request_token'] = (auth.request_token)
+        # session['request_token'] = (auth.request_token)
+        # session.modified = True
         print("debug ---1---")
-        print(session)
+        print(sess)
         return redirect(redirect_url)
 
     except tweepy.TweepError:
@@ -74,9 +74,9 @@ def verify():
 
     auth = tweepy.OAuthHandler(CONSUMER_KEY, CONSUMER_SECRET)
     print("debug ---2---")
-    print(session)
-    auth.request_token = {'oauth_token': session['request_token']['oauth_token'],
-                          'oauth_token_secret': session['request_token']['oauth_token_secret']}
+    print(sess)
+    auth.request_token = {'oauth_token': sess['request_token']['oauth_token'],
+                          'oauth_token_secret': sess['request_token']['oauth_token_secret']}
 
     try:
         auth.get_access_token(verifier)
@@ -85,11 +85,11 @@ def verify():
 
     api = tweepy.API(auth)
 
-    session['api'] = api
-    session['access_token_key'] = auth.access_token
-    session['access_token_secret'] = auth.access_token_secret
+    sess['api'] = api
+    sess['access_token_key'] = auth.access_token
+    sess['access_token_secret'] = auth.access_token_secret
     print("debug ---3---")
-    print(session)
+    print(sess)
 
     return redirect(url_for('search'))
 
@@ -123,10 +123,10 @@ def result():
 
         timer.start()
         print("At router /request")
-        print(type(session))
-        print(session)
+        print(type(sess))
+        print(sess)
         from twi_search import TwiSearch
-        twi = TwiSearch(session)
+        twi = TwiSearch(sess)
         search_result = twi.make_search_result(search_word_dict)
 
         print("----- TwiSearch        ----- Duration  : {}".format(timer.stop()))

--- a/router.py
+++ b/router.py
@@ -11,7 +11,7 @@ CONSUMER_KEY    = SETTING['twitter']['CONSUMER_KEY']
 CONSUMER_SECRET = SETTING['twitter']['CONSUMER_SECRET']
 CALLBACK_URL    = SETTING['twitter']['CALLBACK_URL']
 
-sess = {}
+# sess = {}
 
 app = Flask(__name__)
 app.secret_key = SETTING['flask']['SECRET_KEY']
@@ -38,6 +38,9 @@ timer = Timer()
 
 @app.route("/")
 def top():
+
+    session.clear()
+
     return render_template("top.html")
 
 
@@ -87,6 +90,8 @@ def verify():
     session['api'] = api
     session['access_token_key'] = auth.access_token
     session['access_token_secret'] = auth.access_token_secret
+    print("debug ---3---")
+    print(session)
 
     return redirect(url_for('search'))
 

--- a/router.py
+++ b/router.py
@@ -52,7 +52,7 @@ def detail():
 def oauth():
     # for desk top app, giving callback_url causes an error
     auth = tweepy.OAuthHandler(CONSUMER_KEY, CONSUMER_SECRET)
-
+    global sess
     try:
         redirect_url = auth.get_authorization_url()
         sess['request_token'] = (auth.request_token)
@@ -69,7 +69,7 @@ def oauth():
 
 @app.route("/verify")
 def verify():
-
+    global sess
     verifier = request.args['oauth_verifier']
 
     auth = tweepy.OAuthHandler(CONSUMER_KEY, CONSUMER_SECRET)
@@ -103,6 +103,7 @@ def search():
 
 @app.route("/result", methods=['post'])
 def result():
+    global sess
     if request.method == 'POST':
 
         timer.start()

--- a/router.py
+++ b/router.py
@@ -38,9 +38,6 @@ timer = Timer()
 
 @app.route("/")
 def top():
-
-    session.modified = True
-
     return render_template("top.html")
 
 
@@ -59,7 +56,8 @@ def oauth():
     try:
         redirect_url = auth.get_authorization_url()
         # sess['request_token'] = (auth.request_token)
-        session['request_token'] = (auth.request_token)
+        session['request_token'].append(auth.request_token)
+        session.modified = True
         print("debug ---1---")
         print(session)
         return redirect(redirect_url)

--- a/router.py
+++ b/router.py
@@ -119,7 +119,9 @@ def result():
 
 
         timer.start()
-
+        print("At router /request")
+        print(type(session))
+        print(session)
         from twi_search import TwiSearch
         twi = TwiSearch(session)
         search_result = twi.make_search_result(search_word_dict)

--- a/router.py
+++ b/router.py
@@ -56,6 +56,8 @@ def oauth():
     try:
         redirect_url = auth.get_authorization_url()
         sess['request_token'] = (auth.request_token)
+        print("debug ---1---")
+        print(sess)
         return redirect(redirect_url)
 
     except tweepy.TweepError:
@@ -69,7 +71,8 @@ def verify():
     verifier = request.args['oauth_verifier']
 
     auth = tweepy.OAuthHandler(CONSUMER_KEY, CONSUMER_SECRET)
-
+    print("debug ---2---")
+    print(sess)
     auth.request_token = {'oauth_token': sess['request_token']['oauth_token'],
                           'oauth_token_secret': sess['request_token']['oauth_token_secret']}
 

--- a/router.py
+++ b/router.py
@@ -39,7 +39,8 @@ timer = Timer()
 @app.route("/")
 def top():
 
-    session.clear()
+    del session
+    session.modified = True
 
     return render_template("top.html")
 

--- a/router.py
+++ b/router.py
@@ -1,7 +1,7 @@
 # coding: UTF-8
 
 import logging
-from flask import Flask, redirect, render_template, request, url_for
+from flask import Flask, redirect, render_template, request, url_for, session
 import tweepy
 from settings import SETTING
 from timer import Timer
@@ -55,9 +55,10 @@ def oauth():
 
     try:
         redirect_url = auth.get_authorization_url()
-        sess['request_token'] = (auth.request_token)
+        # sess['request_token'] = (auth.request_token)
+        session['request_token'] = (auth.request_token)
         print("debug ---1---")
-        print(sess)
+        print(session)
         return redirect(redirect_url)
 
     except tweepy.TweepError:
@@ -72,9 +73,9 @@ def verify():
 
     auth = tweepy.OAuthHandler(CONSUMER_KEY, CONSUMER_SECRET)
     print("debug ---2---")
-    print(sess)
-    auth.request_token = {'oauth_token': sess['request_token']['oauth_token'],
-                          'oauth_token_secret': sess['request_token']['oauth_token_secret']}
+    print(session)
+    auth.request_token = {'oauth_token': session['request_token']['oauth_token'],
+                          'oauth_token_secret': session['request_token']['oauth_token_secret']}
 
     try:
         auth.get_access_token(verifier)
@@ -83,9 +84,9 @@ def verify():
 
     api = tweepy.API(auth)
 
-    sess['api'] = api
-    sess['access_token_key'] = auth.access_token
-    sess['access_token_secret'] = auth.access_token_secret
+    session['api'] = api
+    session['access_token_key'] = auth.access_token
+    session['access_token_secret'] = auth.access_token_secret
 
     return redirect(url_for('search'))
 
@@ -120,7 +121,7 @@ def result():
         timer.start()
 
         from twi_search import TwiSearch
-        twi = TwiSearch(sess)
+        twi = TwiSearch(session)
         search_result = twi.make_search_result(search_word_dict)
 
         print("----- TwiSearch        ----- Duration  : {}".format(timer.stop()))

--- a/router.py
+++ b/router.py
@@ -39,7 +39,6 @@ timer = Timer()
 @app.route("/")
 def top():
 
-    del session
     session.modified = True
 
     return render_template("top.html")

--- a/session_namager.py
+++ b/session_namager.py
@@ -8,6 +8,6 @@ from tweepy import API
 class SessionManager(JSONEncoder, JSONDecoder, API):
 
     def default(self , obj) :
-        if isinstance(obj, API):  # NotSettedParameterは'NotSettedParameter'としてエンコード
-            return 'NotSettedParameter'
+        if isinstance(obj, API):  # APIは'API'としてエンコード
+            return 'API'
         return JSONEncoder.default(self, obj)  # 他の型はdefaultのエンコード方式を使用

--- a/session_namager.py
+++ b/session_namager.py
@@ -1,0 +1,13 @@
+# coding: UTF-8
+
+
+from json import JSONEncoder, JSONDecoder
+from tweepy import API
+
+
+class SessionManager(JSONEncoder, JSONDecoder, API):
+
+    def default(self , obj) :
+        if isinstance(obj, API):  # NotSettedParameterは'NotSettedParameter'としてエンコード
+            return 'NotSettedParameter'
+        return JSONEncoder.default(self, obj)  # 他の型はdefaultのエンコード方式を使用

--- a/text_segmentation.py
+++ b/text_segmentation.py
@@ -6,8 +6,6 @@ import MeCab
 
 class TextSegmentation(object):
 
-
-
     hiragana = []
 
     def __init__(self, args=(12353, 12436)):
@@ -26,7 +24,6 @@ class TextSegmentation(object):
         mecab = MeCab.Tagger("-Ochasen")
         mecab.parse('')
         node = mecab.parseToNode(text)
-
 
         r_dict = {}
         count = 0

--- a/twi_search.py
+++ b/twi_search.py
@@ -23,8 +23,6 @@ class TwiSearch(object):
 
     twi = Twitter()
 
-
-
     def __init__(self, sess):
         print("At TwiSearch init")
         print(type(sess))

--- a/twi_search.py
+++ b/twi_search.py
@@ -26,6 +26,9 @@ class TwiSearch(object):
 
 
     def __init__(self, sess):
+        print("At TwiSearch init")
+        print(type(sess))
+        print(sess)
 
         # self.session = sess
         oauth_token = sess['access_token_key']

--- a/wsgi.py
+++ b/wsgi.py
@@ -1,5 +1,7 @@
 # -*- coding: utf-8 -*-
 from router import app
 
+
+
 if __name__ == "__main__":
     app.run()


### PR DESCRIPTION
Two errors
- Key error: 'request_token'
- TypeError: 'API' is not JSON serializable
while Oauth dance were solved by adding SessionManager. SessionManager converts tweepy.API object into JSON serializable.